### PR TITLE
Switch to using an argument parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+clap = { version = "4.5.23", features = ["cargo", "derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,42 @@
+use clap::Parser;
+
+/// The ToyQL query engine.
+///
+/// Processes queries, either from the command line or from a file.
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None, arg_required_else_help = true)]
+struct Args {
+    /// Files containing query text
+    #[arg(short = 'f', long = "file")]
+    query_files: Vec<String>,
+
+    /// Literal query text
+    queries: Vec<String>,
+}
+
+fn run_from_args(args: Args) {
+    for file in args.query_files {
+        println!("I would parse the external file {}", file);
+    }
+    for query in args.queries {
+        println!("I would execute the query {}", query);
+    }
+}
+
 /// The "real" main entry point of our binary target, relocated to a lib so that
 /// rust-test can reach it.
 pub fn _main() {
-    println!("Hello, World!");
-}
+    let args = Args::parse();
 
+    run_from_args(args)
+}
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// For illustrative purposes:  A trivial smoke test.
     #[test]
     fn smoke_test() {
-        _main();
-    }
+        run_from_args(Args{query_files:vec!(), queries:vec!()});
+    }    
 }

--- a/tests/system_smoke_test.py
+++ b/tests/system_smoke_test.py
@@ -6,10 +6,33 @@ import unittest  # To get pretty error messages.
 class SystemSmokeTest(unittest.TestCase):
     """The simplest possible system test."""
 
-    def test_smoke(self):
-        """Does this target run at all?"""
-        output = subprocess.check_output(["cargo", "run"], encoding="UTF-8")
-        self.assertEqual(output, "Hello, World!\n")
+    dut = "target/debug/toyql"
+
+    def test_help(self):
+        """Checks that we can run as far as the help text."""
+        output = subprocess.run(
+            [self.dut, "--help"],
+            capture_output=True,
+            encoding="UTF-8")
+        self.assertEqual(output.returncode, 0)
+        self.assertIn("ToyQL query engine", output.stdout)
+        self.assertEqual(output.stderr.rstrip(), "")
+
+    def test_files(self):
+        """Test that files on the command line are processed."""
+        output = subprocess.check_output(
+            [self.dut, "-f", "file_1", "-f", "file_2"],
+            encoding="UTF-8")
+        self.assertIn("file_1", output)
+        self.assertIn("file_2", output)
+
+    def test_queries(self):
+        """Test that query text on the command line is processed."""
+        output = subprocess.check_output(
+            [self.dut, "query_1", "query_2"],
+            encoding="UTF-8")
+        self.assertIn("query_1", output)
+        self.assertIn("query_2", output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
 * We now use `clap` to parse arguments
 * Corresponding testing expansion