### PR TITLE
Parsing reorg and strings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.5.23", features = ["cargo", "derive"] }
+itertools = "~0.14"
 nom = "~8"
 rand = "0.9.0"
 serde = "1.0.219"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ fn run_from_args(args: Args) -> Result<(), i32> {
     }
     for query in args.queries {
         println!("Executing the query {}", query);
-        let parsed_literal = literals::parsing::literal(&query);
+        let parsed_literal = literals::parsing::apply_grammar(&query);
         match parsed_literal {
             Ok((r, literals::LiteralValue::Int(i))) => println!("Got int {} ...{}", i, r),
             Ok((r, literals::LiteralValue::Float(f))) => println!("Got float {} ...{}", f, r),

--- a/src/literals.rs
+++ b/src/literals.rs
@@ -149,14 +149,14 @@ pub mod parsing {
             match str::parse::<String>(input) {
                 Ok(x) => {
                     let without_quotes = x.trim_matches('\"').to_string();
-                    let without_backslash = without_quotes.replace("\\", "");
-                    Ok(LiteralValue::String(without_backslash))
+                    Ok(LiteralValue::String(without_quotes))
                 }
                 Err(x) => Err(x),
             }
         }
 
         pub fn apply_grammar(input: &str) -> IResult<&str, LiteralValue> {
+            println!("Attempting to apply the string grammar to ->{}<-", input);
             let string_grammar = recognize(
                 delimited(
                     char('"'),


### PR DESCRIPTION
* Reorganize parser code into namespaces so that I don't have long function names
* Fix the serialization / deserialization loop for escaped strings
* Add a full double loop test of mixed literals.